### PR TITLE
README: Change the URL for the `C-Reduce` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ some manual editing first to get rid of dependencies that take a long time to lo
 
 ## Requirements
 
-- [C-Reduce](https://embed.cs.utah.edu/creduce/) 2.8.0+, on PATH
+- [C-Reduce](https://github.com/csmith-project/creduce) 2.8.0+, on PATH
 - Julia 1.0+, on PATH
 
 


### PR DESCRIPTION
The current URL is giving me a 404:

```
$ curl -I -X GET https://embed.cs.utah.edu/creduce/
HTTP/1.1 404 Not Found
Date: Thu, 21 Nov 2024 00:46:32 GMT
Server: Apache/2.4.29 (Ubuntu)
Last-Modified: Thu, 26 Oct 2023 13:20:22 GMT
ETag: "1d3-6089e6f1cfdbe"
Accept-Ranges: bytes
Content-Length: 467
X-Frame-Options: sameorigin
Content-Type: text/html
```