### PR TITLE
More Mac compatibility

### DIFF
--- a/activate
+++ b/activate
@@ -20,13 +20,13 @@ if [[ "$(pwd)" != "$DIR" ]]; then
         # there may be non-sources we need) and the environment (to rewrite the Manifest)
         for dir in dev environments; do
             if [[ -d "$DEPOT/$dir" ]]; then
-                cp -arf "$DEPOT/$dir" depot/
+                cp -Rp "$DEPOT/$dir" depot/
             fi
         done
 
         if [[ -d depot/environments ]]; then
             # rewrite manifests to point dev'ed packages to our new depot
-            sed -i "s#path = \".*/depot/dev#path = \"$(pwd)/depot/dev#g" depot/environments/*/Manifest.toml
+            sed -i '' "s#path = \".*/depot/dev#path = \"$(pwd)/depot/dev#g" depot/environments/*/Manifest.toml
         fi
     fi
 

--- a/julia
+++ b/julia
@@ -6,4 +6,4 @@ set -ue
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$DIR"/activate
 
-julia +nightly -O0 -t1 --startup-file=no "$@"
+julia -O0 -t1 --startup-file=no "$@"


### PR DESCRIPTION
Without this I got:

- `cp: the -R and -r options may not be specified together`
- `sed: 1: "depot/environments/v1.1 ...": extra characters at the end of d command`

